### PR TITLE
Suggested change to download approach

### DIFF
--- a/astroquery/esa_hubble/__init__.py
+++ b/astroquery/esa_hubble/__init__.py
@@ -28,6 +28,7 @@ class Conf(_config.ConfigNamespace):
                                          "ehst-sl-server/servlet/"
                                          "metadata-action?",
                                          "Main url for retriving hst metadata")
+    TIMEOUT = 60
 
 
 conf = Conf()


### PR DESCRIPTION
This is how the user will interact with the new method:
```
In [1]: from astroquery.esa_hubble import ESAHubble
Created TAP+ (v1.0.1) - Connection:
    Host: hst.esac.esa.int
    Use HTTPS: False
    Port: 80
    SSL Port: 443

In [2]: rslt = ESAHubble.download_product("J6FL25S4Q", verbose=True)
Downloading URL http://archives.esac.esa.int/ehst-sl-server/servlet/data-action?OBSERVATION_ID=J6FL25S4Q&CALIBRATION_LEVEL=RAW to J6FL25S4Q.tar ... [Done]
INFO: Wrote http://archives.esac.esa.int/ehst-sl-server/servlet/data-action?OBSERVATION_ID=J6FL25S4Q&CALIBRATION_LEVEL=RAW to J6FL25S4Q.tar [astroquery.esa_hubble.core]

In [3]: rslt
Out[3]: 'J6FL25S4Q.tar'
```